### PR TITLE
Depend on dnsdock

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,21 @@ ex) add server3 to server1 cluster
 docker exec -it $(docker ps -q -f name=server3) consul join c3d_server1.docker
 ```
 
+## Exec command to All members
+
+ex) exec command via server2
+
+```
+docker exec -it $(docker ps -q -f name=server2) consul exec cat /etc/redhat-release
+```
+
 ## DNS
 
 use DNS for two-way access of container each other
 
 see [tonistiigi/dnsdock](https://github.com/tonistiigi/dnsdock)
+
+## TODO
+
+- [ ] Add Consul Web UI
+- [ ] Add Service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,22 +9,30 @@ server1:
   build: .
   dns:
     - 172.17.0.1
+  links:
+    - dnsdock
   command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/bootstrap
 
 server2:
   build: .
   dns:
     - 172.17.0.1
+  links:
+    - dnsdock
   command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
 
 server3:
   build: .
   dns:
     - 172.17.0.1
+  links:
+    - dnsdock
   command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
 
 node1:
   build: .
   dns:
     - 172.17.0.1
+  links:
+    - dnsdock
   command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/client


### PR DESCRIPTION
dnsdockよりさきにserver1等が立ち上がると名前解決できなくてクラスタへのjoinに失敗しそう(してる)なのでdnsdock依存の設定追加してdnsdockより後にcontainer起動するようにした
