### PR TITLE
Refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ RUN \
   rm -f consul.zip && \
   mv consul /usr/local/sbin && \
   chmod 755 /usr/local/sbin/consul && \
-  mkdir -p /etc/consul.d/{bootstrap,server,client}
+  mkdir -p /etc/consul.d/{server,client}
 
 # configure consul
-COPY ./bootstrap.json /etc/consul.d/bootstrap/config.json
 COPY ./server.json    /etc/consul.d/server/config.json
 COPY ./client.json    /etc/consul.d/client/config.json
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ ex) exec command via server2
 docker exec -it $(docker ps -q -f name=server2) consul exec cat /etc/redhat-release
 ```
 
+## Scale cluster
+
+ex) scale server3
+
+```
+docker-compose scale server3=4
+```
+
 ## Consul Web UI
 
 check your docker-machine ip address

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,8 +1,0 @@
-{
-    "datacenter": "c3d-dc",
-    "bootstrap_expect": 3,
-    "server": true,
-    "data_dir": "/var/consul",
-    "encrypt": "Xa002vevVldUrIJlFymgOg==",
-    "client_addr": "0.0.0.0"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,7 @@ server1:
     - 172.17.0.1
   links:
     - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/bootstrap -ui-dir=/var/www/
-  ports:
-    - "8500:8500"
+  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
 
 server2:
   build: .
@@ -31,10 +29,12 @@ server3:
     - dnsdock
   command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
 
-node1:
+web_ui:
   build: .
   dns:
     - 172.17.0.1
   links:
     - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/client
+  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/client -ui-dir=/var/www/
+  ports:
+    - "8500:8500"

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
     "datacenter": "c3d-dc",
-    "bootstrap": false,
+    "bootstrap_expect": 3,
     "server": true,
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",


### PR DESCRIPTION
bootstrap用の設定消した

古いバージョンの感じでbootstrap用の設定書いて明示的に初回起動時にリーダーを決めていたけど、expectの設定だけ書いとけばその数に達したら自動でリーダー選出が始まるので明示的にリーダー起動する必要が無くなったのでした
