### PR TITLE
Improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,13 @@ RUN \
   rm -f consul_0.6.4_linux_amd64.zip && \
   mv consul /usr/local/bin && \
   chmod 755 /usr/local/bin/consul && \
-  mkdir -p /etc/consul.d/{server,client} && \
+  mkdir -p /etc/consul.d/leader && \
+  mkdir -p /etc/consul.d/server && \
+  mkdir -p /etc/consul.d/client && \
   apk del build-dependencies
 
 # configure consul
+COPY ./leader.json    /etc/consul.d/leader/config.json
 COPY ./server.json    /etc/consul.d/server/config.json
 COPY ./client.json    /etc/consul.d/client/config.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM centos:7
+FROM alpine
 
 # install consul
 RUN \
-  yum install -y curl wget unzip bind-utils && \
-  wget --no-check-certificate -O consul.zip https://releases.hashicorp.com/consul/0.6.0/consul_0.6.0_linux_amd64.zip && \
-  unzip consul.zip && \
-  rm -f consul.zip && \
-  mv consul /usr/local/sbin && \
-  chmod 755 /usr/local/sbin/consul && \
-  mkdir -p /etc/consul.d/{server,client}
+  apk --update add --no-cache --virtual build-dependencies \
+  curl \
+  wget \
+  unzip && \
+  wget https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip && \
+  unzip consul_0.6.4_linux_amd64.zip && \
+  rm -f consul_0.6.4_linux_amd64.zip && \
+  mv consul /usr/local/bin && \
+  chmod 755 /usr/local/bin/consul && \
+  mkdir -p /etc/consul.d/{server,client} && \
+  apk del build-dependencies
 
 # configure consul
 COPY ./server.json    /etc/consul.d/server/config.json

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker-compose up
 ex) login to server2
 
 ```
-docker exec -it $(docker ps -q -f name=server2) bash
+docker exec -it $(docker ps -q -f name=server2) sh
 ```
 
 ## Check members
@@ -67,12 +67,6 @@ docker-machine ip <docker-machine name>
 open url -> http://\<your docker-machine ip address\>:8500/ui/
 
 ![consul_web_ui](./images/consul_web_ui.gif)
-
-## DNS
-
-use DNS for two-way access of container each other
-
-see [tonistiigi/dnsdock](https://github.com/tonistiigi/dnsdock)
 
 ## TODO
 

--- a/client.json
+++ b/client.json
@@ -4,5 +4,5 @@
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",
     "client_addr": "0.0.0.0",
-    "start_join": ["c3d_server1.docker", "c3d_server2.docker", "c3d_server3.docker"]
+    "start_join": ["server1"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,23 @@
-dnsdock:
-  image: tonistiigi/dnsdock
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  ports:
-    - 172.17.0.1:53:53/udp
-
 server1:
   build: .
-  dns:
-    - 172.17.0.1
-  links:
-    - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
+  command: /usr/local/bin/consul agent -config-dir=/etc/consul.d/leader
 
 server2:
   build: .
-  dns:
-    - 172.17.0.1
   links:
-    - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
+    - server1
+  command: /usr/local/bin/consul agent -config-dir=/etc/consul.d/server
 
 server3:
   build: .
-  dns:
-    - 172.17.0.1
   links:
-    - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/server
+    - server1
+  command: /usr/local/bin/consul agent -config-dir=/etc/consul.d/server
 
 web_ui:
   build: .
-  dns:
-    - 172.17.0.1
   links:
-    - dnsdock
-  command: /usr/local/sbin/consul agent -config-dir=/etc/consul.d/client -ui-dir=/var/www/
+    - server1
+  command: /usr/local/bin/consul agent -config-dir=/etc/consul.d/client -ui-dir=/var/www/
   ports:
     - "8500:8500"

--- a/leader.json
+++ b/leader.json
@@ -5,5 +5,5 @@
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",
     "client_addr": "0.0.0.0",
-    "start_join": ["server1"]
+    "start_join": ["127.0.0.1"]
 }


### PR DESCRIPTION
dnsdock頼らなくても動くようにした

やったこと
- dnsdockの代わりに初期リーダー用のコンテナ設定(127.0.0.1にbind)
- 他のコンテナはリーダー用コンテナにlinkし、bind先はリーダーのホスト名にする
- ついでにcentos7 -> alpine
- ついでにconsulバージョンアップ
