### PR TITLE
Update consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 # consul version
-ARG version="0.6.4"
+ARG version="0.7.2"
 
 # install consul
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM alpine
 
+# consul version
+ARG version="0.6.4"
+
 # install consul
 RUN \
   apk --update add --no-cache --virtual build-dependencies \
   curl \
   wget \
   unzip && \
-  wget https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip && \
-  unzip consul_0.6.4_linux_amd64.zip && \
-  rm -f consul_0.6.4_linux_amd64.zip && \
+  wget https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip && \
+  unzip consul_${version}_linux_amd64.zip && \
+  rm -f consul_${version}_linux_amd64.zip && \
   mv consul /usr/local/bin && \
   chmod 755 /usr/local/bin/consul && \
   mkdir -p /etc/consul.d/leader && \


### PR DESCRIPTION
ARGを使ってバージョンを指定するようにした。

🆗 

```
 docker exec -it $(docker ps -q -f name=server2) consul exec 'consul -v'
    1b96ad3683d6: Consul v0.7.2
    1b96ad3683d6: Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
    1b96ad3683d6:
    a7059ca3e671: Consul v0.7.2
    a7059ca3e671: Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
    a7059ca3e671:
    1f0cc43c9161: Consul v0.7.2
    1f0cc43c9161: Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
    1f0cc43c9161:
    acf025a068a8: Consul v0.7.2
    acf025a068a8: Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
    acf025a068a8:
==> 1b96ad3683d6: finished with exit code 0
==> a7059ca3e671: finished with exit code 0
==> acf025a068a8: finished with exit code 0
==> 1f0cc43c9161: finished with exit code 0
4 / 4 node(s) completed / acknowledged
```