### PR TITLE
V0.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 # consul version
-ARG version="0.7.2"
+ARG version="0.8.3"
 
 # install consul
 RUN \

--- a/client.json
+++ b/client.json
@@ -4,5 +4,6 @@
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",
     "client_addr": "0.0.0.0",
-    "start_join": ["server1"]
+    "start_join": ["server1"],
+    "disable_host_node_id": true
 }

--- a/leader.json
+++ b/leader.json
@@ -5,5 +5,6 @@
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",
     "client_addr": "0.0.0.0",
-    "start_join": ["127.0.0.1"]
+    "start_join": ["127.0.0.1"],
+    "disable_host_node_id": true
 }

--- a/server.json
+++ b/server.json
@@ -5,5 +5,6 @@
     "data_dir": "/var/consul",
     "encrypt": "Xa002vevVldUrIJlFymgOg==",
     "client_addr": "0.0.0.0",
-    "start_join": ["server1"]
+    "start_join": ["server1"],
+    "disable_host_node_id": true
 }


### PR DESCRIPTION
0.8.3にアップデート＆consulが新しいバージョンで動かなくなっていたので対応。

consulエージェントを同一ホスト上から複数実行すると、consulはホストからの情報を利用してnode idを生成するようなのでnode idが競合する。
これは同一ホスト上に立ち上げたDockerのコンテナ上に立ち上げたconsulでも同様に発生するっぽい。

ので`-disable-host-node-id`をつけて強制的にランダムなnode idを生成するようにした。

- https://www.consul.io/docs/agent/options.html#_disable_host_node_id
- https://github.com/joyent/containerpilot/issues/322